### PR TITLE
Fix bind example test

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ class Example {
 }
 
 let e = new Example();
-assert.equal(e.foo(), e);
+assert.equal(e.foo.call(null), e);
 ```
 
 


### PR DESCRIPTION
The current bind example test will succeed even without using `@bind`. This is because of the way that `e.foo` is being called in the example test. When it is called like `e.foo()`, the `e` is to the left of the dot, so `e` is passed in as the `this` argument to the `foo` function. So the test `assert.equal(e.foo(), e)` will be `true` regardless of whether `@bind` is used. To fix this, we can change the test to `assert.equal(e.call(null), e)` to explicitly pass in `null` as the `this` argument for `foo` using `Function.prototype.call`.